### PR TITLE
Remove console.log from private library method

### DIFF
--- a/app/js/galleries/AbstractGallery.ts
+++ b/app/js/galleries/AbstractGallery.ts
@@ -345,14 +345,6 @@ export abstract class AbstractGallery<Model extends ModelAttributes = any> {
      * @returns {ItemOptions}
      */
     private getItemOptions(): ItemOptions {
-        console.log({
-            lightbox: this.options.lightbox,
-            selectable: this.options.selectable,
-            activable: this.options.activable,
-            gap: this.options.gap,
-            showLabels: this.options.showLabels,
-            cover : this.options.cover
-        });
         return {
             lightbox: this.options.lightbox,
             selectable: this.options.selectable,


### PR DESCRIPTION
This spams the console logs a little much when using this library.