### PR TITLE
Add option for an individual focal point on images

### DIFF
--- a/src/js/Item.ts
+++ b/src/js/Item.ts
@@ -8,6 +8,7 @@ export declare interface ItemOptions {
     gap?: number;
     showLabels?: 'hover' | 'never' | 'always';
     cover?: boolean;
+    focalpoint?: boolean;
 }
 
 export interface ItemTitle {
@@ -242,6 +243,13 @@ export class Item<Model extends ModelAttributes = any> {
         img.setAttribute('src', this.model.thumbnailSrc);
 
         this._image.style.backgroundImage = 'url(' + this.model.thumbnailSrc + ')';
+
+        if (this.options.focalpoint) {
+            if (this.model.focalpoint !== undefined) {
+                this._image.style.backgroundPosition = this.model.focalpoint;
+                this._image.classList.remove('cover');
+            }
+        }
 
         img.addEventListener('load', () => {
             this._element.classList.add('loaded');

--- a/src/js/galleries/AbstractGallery.ts
+++ b/src/js/galleries/AbstractGallery.ts
@@ -59,6 +59,11 @@ export interface ModelAttributes extends SizedModel {
      * If item is selected
      */
     selected?: boolean;
+
+    /**
+     * Focalpoint for backgroundPosition
+     */
+    focalpoint?: string;
 }
 
 export interface GalleryOptions extends ItemOptions {
@@ -128,6 +133,7 @@ export abstract class AbstractGallery<Model extends ModelAttributes = any> {
         infiniteScrollOffset: 0,
         photoSwipeOptions: null,
         cover: true,
+        focalpoint: false,
     };
 
     protected photoswipeDefaultOptions: PhotoSwipeOptions = {
@@ -313,7 +319,7 @@ export abstract class AbstractGallery<Model extends ModelAttributes = any> {
 
         // Complete collection
         models.forEach((model: Model) => {
-            const itemOptions = pick(this.options, ['lightbox', 'selectable', 'activable', 'gap', 'showLabels', 'cover']);
+            const itemOptions = pick(this.options, ['lightbox', 'selectable', 'activable', 'gap', 'showLabels', 'cover' ,'focalpoint']);
             const item = new Item<Model>(itemOptions, model);
             this._collection.push(item);
 

--- a/testing/unit/masonry.spec.ts
+++ b/testing/unit/masonry.spec.ts
@@ -25,6 +25,7 @@ fdescribe('Masonry Gallery', () => {
             infiniteScrollOffset: 0,
             photoSwipeOptions: null,
             cover: true,
+            focalpoint: false,
         };
 
         let gallery = new Masonry(null, {columnWidth: 123, gap: 4});
@@ -43,4 +44,3 @@ fdescribe('Masonry Gallery', () => {
 
     });
 });
-

--- a/testing/unit/natural.spec.ts
+++ b/testing/unit/natural.spec.ts
@@ -27,6 +27,7 @@ describe('Natural Gallery', () => {
             infiniteScrollOffset: 0,
             photoSwipeOptions: null,
             cover: true,
+            focalpoint: false,
         };
 
         let gallery = new Natural(null, {rowHeight: 123, gap: 4});

--- a/testing/unit/square.spec.ts
+++ b/testing/unit/square.spec.ts
@@ -25,6 +25,7 @@ fdescribe('Masonry Gallery', () => {
             infiniteScrollOffset: 0,
             photoSwipeOptions: null,
             cover: true,
+            focalpoint: false,
         };
 
         let gallery = new Square(null, {itemsPerRow: 123, gap: 4});
@@ -43,4 +44,3 @@ fdescribe('Masonry Gallery', () => {
 
     });
 });
-


### PR DESCRIPTION
Hi,
This is a follow up on #24 regarding an optional center for thumbnails.
I gave it another go and it seemed easy to implement.
- - -

Gallery option: focalpoint: boolean
Image item property: focalpoint: string

If an image item has a focalpoint property, e.g. "20% 89%", this will be
applied as a background-position style on the thumbnail and the
background-size:cover is removed.

For items with focalpoint set, thumbnail size should be larger than
gallery option rowHeight.