### PR TITLE
natural - fixed incorrect row height calculation

### DIFF
--- a/src/js/galleries/Natural.ts
+++ b/src/js/galleries/Natural.ts
@@ -111,7 +111,7 @@ export class Natural<Model extends ModelAttributes = ModelAttributes> extends Ab
     }
 
     public static getRowHeight(models: SizedModel[], containerWidth: number, margin: number, ratioLimits?: RatioLimits): number {
-        return containerWidth / this.getRatios(models, ratioLimits) - margin * (models.length - 1);
+        return (containerWidth - margin * (models.length - 1)) / this.getRatios(models, ratioLimits);
     }
 
     /**

--- a/testing/unit/natural.spec.ts
+++ b/testing/unit/natural.spec.ts
@@ -73,7 +73,7 @@ describe('Natural Gallery', () => {
         expect(rowHeight1).toBe(272.72727272727275);
 
         const rowHeight2 = Natural.getRowHeight(images, 1000, 10, {});
-        expect(rowHeight2).toBe(252.72727272727275);
+        expect(rowHeight2).toBe(267.2727272727273);
 
         expect(rowHeight2).toBeLessThan(rowHeight1);
 
@@ -196,9 +196,9 @@ describe('Natural Gallery', () => {
         gallery.organizeItems(gallery.collection, 0, 999);
 
         const result = [
-            {width: 384, height: 232, row: 0},
-            {width: 190, height: 232, row: 0},
-            {width: 385, height: 232, row: 0},
+            {width: 392, height: 261, row: 0},
+            {width: 174, height: 261, row: 0},
+            {width: 393, height: 261, row: 0},
             {width: 266, height: 400, row: 1},
             {width: 267, height: 400, row: 1},
         ];
@@ -250,10 +250,10 @@ describe('Natural Gallery', () => {
 
         const result = [
             {width: 480, height: 320, row: 0},
-            {width: 146, height: 201, row: 1},
-            {width: 314, height: 201, row: 1},
-            {width: 229, height: 339, row: 2},
-            {width: 231, height: 339, row: 2},
+            {width: 141, height: 212, row: 1},
+            {width: 319, height: 212, row: 1},
+            {width: 229, height: 344, row: 2},
+            {width: 231, height: 344, row: 2},
         ];
 
         expect(gallery.collection.map(getSize)).toEqual(result);


### PR DESCRIPTION
`getRowHeight` for `Natural` gallery type is currently being calculated incorrectly - width space reserved for margins is being subtracted only after ratio is calculated, which results in final element ratio being lesser in height than image ratio, which results in image not fitting in its container completely and having pixels at top/bottom slightly cut.   

issue is visible on demo (https://ecodev.github.io/natural-gallery-js/), but it's way more visible in my PS v5 PR on thumbnail -> full screen image transition animation - it looks like the image is kinda instantly sliding into full height and only then it starts scaling up.

margins should be subtracted from total available width space before being divided by row width/height ratio, so that the images ratios are being kept - change in this PR seems to fix this issue

